### PR TITLE
修复运行失败时崩溃的问题

### DIFF
--- a/Plugins/Core.ahk
+++ b/Plugins/Core.ahk
@@ -32,7 +32,14 @@ CmdRunOnly:
 return
 
 AhkRun:
-    Run, %Arg%
+    try
+    {
+        Run, %Arg%
+    }
+    catch e  
+    {
+        MsgBox, 运行命令 %Arg% 失败
+    }
 return
 
 ShowArg:


### PR DESCRIPTION
run 一个命令的时候可能会失败而崩溃。修改后会弹出一个提示框报错。
