### PR TITLE
配置HideCol2选项打开时，如果第一个选项的文件名只有两个字符，会造成显示错位。

### DIFF
--- a/RunZ.ahk
+++ b/RunZ.ahk
@@ -1837,7 +1837,7 @@ AlignText(text)
         hasCol2 := true
         Loop, Parse, text, `n, `r
         {
-            if (SubStr(text, 3, 1) != "|" || SubStr(text, 8, 1) != "|")
+            if (SubStr(A_LoopField, 3, 1) != "|" || SubStr(A_LoopField, 8, 1) != "|")
             {
                 hasCol2 := false
                 break


### PR DESCRIPTION
复现方法：添加wt.exe文件，增加rank值到最大，较长的命令显示就会出问题。

ps：不是最好的修改方法，但是最简单的方法。如果所有文件名长度都是2个字符还是会有问题，但是概率极小。